### PR TITLE
Resolves #300 - Set missing participant value on FSDB import

### DIFF
--- a/airscore/core/pilot/participant.py
+++ b/airscore/core/pilot/participant.py
@@ -166,6 +166,8 @@ class Participant(Pilot):
                     pilot.team = el.get('value')
                 elif el.get('name').lower() in ('fai_id', 'fai_licence'):
                     pilot.fai_id = el.get('value')
+                elif el.get('name').lower() in ('class'):
+                    pilot.glider_cert = el.get('value')
                 else:
                     pilot.attributes.append({'attr_value': el.get('name'), 'meta_value': el.get('value')})
 


### PR DESCRIPTION
Populate "glider_cert" field with "class" FsCustomAttribute when importing pilots from FSDB file.