### PR TITLE
fix the integration of Stadia.StamenTerrain map tiles

### DIFF
--- a/airscore/core/console/design_map.py
+++ b/airscore/core/console/design_map.py
@@ -53,7 +53,23 @@ def make_map(
         location = bbox_centre(bbox)
     else:
         location = [45, 10]
-    folium_map = folium.Map(location=location, zoom_start=13, tiles="Stamen Terrain", width='100%', height='75%')
+
+    attr = (
+        '&copy; <a href="https://stadiamaps.com/" target="_blank">Stadia Maps</a>'
+        '&copy; <a href="https://stamen.com/" target="_blank">Stamen Design</a>'
+        '&copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a>'
+        '&copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a>'
+        'integrated by <a href="https://github.com/FAI-CIVL/FAI-Airscore" target="_blank">FAI-Airscore</a>'
+    )
+    tiles = "https://tiles.stadiamaps.com/tiles/stamen_terrain/{z}/{x}/{y}{r}.png"
+    folium_map = folium.Map(
+        location=location,
+        zoom_start=13,
+        tiles=tiles,
+        width='100%',
+        height='75%',
+        attr=attr
+    )
     #     folium.LayerControl().add_to(folium_map)
     '''Define map borders'''
     # at this stage a track (layer_geojason has bbox inside,

--- a/airscore/core/console/task_map.py
+++ b/airscore/core/console/task_map.py
@@ -126,8 +126,21 @@ def dump_flight_to_geojson(flight, geojson_filename_local):
 
 # function to create the map template with optional geojson, circles and points objects
 def make_map(layer_geojson=False, circles=False, points=False):
+    attr = (
+        '&copy; <a href="https://stadiamaps.com/" target="_blank">Stadia Maps</a>'
+        '&copy; <a href="https://stamen.com/" target="_blank">Stamen Design</a>'
+        '&copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a>'
+        '&copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a>'
+        'integrated by <a href="https://github.com/FAI-CIVL/FAI-Airscore" target="_blank">FAI-Airscore</a>'
+    )
+    tiles = "https://tiles.stadiamaps.com/tiles/stamen_terrain/{z}/{x}/{y}{r}.png"
     folium_map = folium.Map(
-        location=[45.922207, 8.673952], zoom_start=13, tiles="Stamen Terrain", width='100%', height='75%'
+        location=[45.922207, 8.673952],
+        zoom_start=13,
+        tiles=tiles,
+        width='100%',
+        height='75%',
+        attr=attr
     )
 
     if layer_geojson:

--- a/airscore/core/map.py
+++ b/airscore/core/map.py
@@ -52,14 +52,23 @@ def make_map(
     else:
         location = [45, 10]
 
+    attr = (
+        '&copy; <a href="https://stadiamaps.com/" target="_blank">Stadia Maps</a> '
+        '&copy; <a href="https://stamen.com/" target="_blank">Stamen Design</a> '
+        '&copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> '
+        '&copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> '
+        'integrated by <a href="https://github.com/FAI-CIVL/FAI-Airscore" target="_blank">FAI-Airscore</a>'
+    )
+    tiles = "https://tiles.stadiamaps.com/tiles/stamen_terrain/{z}/{x}/{y}{r}.png"
     folium_map = folium.Map(
         location=location,
         position='relative',
         zoom_start=13,
-        tiles="Stamen Terrain",
+        tiles=tiles,
         max_bounds=True,
         min_zoom=5,
         prefer_canvas=True,
+        attr=attr
     )
     #     folium.LayerControl().add_to(folium_map)
     '''Define map borders'''


### PR DESCRIPTION
Stamen Maps tiles are not available through Fastly CDN anymore (since October 31, 2023).

This PR fixes the integration of Stadia.StamenTerrain.

see also

- [Migration Guide for Stamen Map Tile Users](https://docs.stadiamaps.com/guides/migrating-from-stamen-map-tiles/)
- [Here comes the future of Stamen Maps (07.28.23)](https://stamen.com/here-comes-the-future-of-stamen-maps/)
- [Stamen x Stadia: the end of the road for Stamen’s legacy map tiles (09.18.23)](https://stamen.com/stamen-x-stadia-the-end-of-the-road-for-stamens-legacy-map-tiles/)
